### PR TITLE
Typo in issuing command, dot at the end required.

### DIFF
--- a/docs/keys.md
+++ b/docs/keys.md
@@ -8,7 +8,7 @@ keys:new("password").
 
 To secure your node so no one can sign transactions, you can either turn off the node, or you can do this command:
 ```
-keys:lock()
+keys:lock().
 ```
 
 To unlock your node so that you can start signing transactions again, do this:


### PR DESCRIPTION
Line 11 - adding `.`

Line 55 - no changes.