### PR TITLE
Add missing step to run  testnet on OSX

### DIFF
--- a/docs/compile_mac.md
+++ b/docs/compile_mac.md
@@ -1,11 +1,20 @@
 install erlang version 18 or higher.
 You may need to install from source http://www.erlang.org/downloads
 
+Or use [Homebrew](https://brew.sh):
+```
+brew install erlang
+```
 
 Use git to download the software, then go into the testnet directory
 ```
 git clone https://github.com/aeternity/testnet.git
 cd testnet
+```
+
+Install the dependencies:
+```
+sh install.sh
 ```
 
 Now you can run your node with ```sh start.sh```


### PR DESCRIPTION
One needs to run `install.sh` before `start.sh` works :)