### PR TITLE
Correct a typo and broken link

### DIFF
--- a/docs/trees.md
+++ b/docs/trees.md
@@ -1,4 +1,4 @@
-There are 8 merkel trees.
+There are 8 merkle trees.
 
 * oracles+
 * orders
@@ -29,7 +29,7 @@ This tree stores channels by an integer channel id.
 
 === accounts
 
-This tree stores accounts by integer id. Each account has 2 merkel roots written in them. One is for a shares tree, the other is for an oracle bets tree.
+This tree stores accounts by integer id. Each account has 2 merkle roots written in them. One is for a shares tree, the other is for an oracle bets tree.
 
 === oracle bets
 

--- a/docs/turn_it_on.md
+++ b/docs/turn_it_on.md
@@ -12,7 +12,7 @@ You can communicate with the running node like this:
 ```
   make release-attach
 ```
-now that you are attached to a node, you can tell it [commands](/commands.md)
+now that you are attached to a node, you can tell it [commands](commands.md)
 
 You can turn off a running node
 ```


### PR DESCRIPTION
Corrects a typo and broken link in the docs