### PR TITLE
Refactor tx_pool

### DIFF
--- a/apps/ae_core/src/consensus/chain/block.erl
+++ b/apps/ae_core/src/consensus/chain/block.erl
@@ -96,7 +96,6 @@ genesis_maker() ->
     Accounts = accounts:write(0, First),
     GovInit = governance:genesis_state(),
     Trees = trees:new(Accounts, 0, 0, 0, 0, GovInit),
-    %io:fwrite(Trees),
     TreeRoot = trees:root_hash(Trees),
     Block = {block_plus,{block,0,
 		     <<0:(8*constants:hash_size())>>,
@@ -126,7 +125,7 @@ genesis_maker() ->
 %            {trees,1,0,0,0,0,72},
 %            0,
 %            {prev_hashes}}.
-block_reward(Trees, Height, ID) -> 
+block_reward(Trees, Height, ID) ->
     OldAccounts = trees:accounts(Trees),
     Governance = trees:governance(Trees),
     BCM = governance:get_value(block_creation_maturity, Governance),

--- a/apps/ae_core/src/consensus/chain/block_absorber.erl
+++ b/apps/ae_core/src/consensus/chain/block_absorber.erl
@@ -57,7 +57,7 @@ save_helper(BlockPlus) ->
     %Hash = testnet_hasher:doit(BlockPlus),
     Hash = block:hash(BlockPlus),
     BF = block:binary_to_file(Hash),
-    db:save(BF, Z).
+    ok = db:save(BF, Z).
     
 save(BlockPlus) ->
     save_helper(BlockPlus),

--- a/apps/ae_core/src/consensus/chain/top.erl
+++ b/apps/ae_core/src/consensus/chain/top.erl
@@ -1,57 +1,94 @@
 -module(top).
 -behaviour(gen_server).
--export([start_link/0,code_change/3,handle_call/3,handle_cast/2,handle_info/2,init/1,terminate/2, add/1,doit/0,test/0]).
+
+%% API
+-export([add/1,
+         doit/0]).
+
+-export([start_link/0]).
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
 -define(LOC, constants:top()).
-init(ok) -> 
-    io:fwrite("start top"),
-    G = block:genesis_maker(),
-    X = db:read(?LOC),
-    Ka = if
-	     X == "" ->
-		 %G = block:genesis(),
-		 block_absorber:save_helper(G),
-		 add_internal(G),
-		 I = keys:pubkey(),
-		 M = constants:master_pub(),
-		 if
-		     I == M -> keys:update_id(1);
-		     true -> ok
-		 end,
-		 block:hash(G);
-	     true ->
-		 X
-	 end,
-    spawn(fun() -> block_hashes:add(block:hash(G)) end),
-    {ok, Ka}.
-    %{ok, []}.
-start_link() -> gen_server:start_link({local, ?MODULE}, ?MODULE, ok, []).
-code_change(_OldVsn, State, _Extra) -> {ok, State}.
-terminate(_, _) -> io:format("died!"), ok.
-handle_info(_, X) -> {noreply, X}.
-handle_cast(_, X) -> {noreply, X}.
-handle_call({add, Block}, _From, X) ->
-    %check which block is higher and store it's hash as the top.
-    %for tiebreakers, prefer the older block.
-    OldBlock = block:read(X),
+
+%% API functions
+
+add(Block) ->
+    gen_server:call(?MODULE, {add, Block}).
+
+doit() ->
+    gen_server:call(?MODULE, top).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, ok, []).
+
+
+%% gen_server callbacks
+
+init(ok) ->
+    lager:info("Start top"),
+    GenesisMakerBlock = block:genesis_maker(),
+    Top = db:read(?LOC),
+    TopHash =
+        case Top of
+            "" ->
+                ok = block_absorber:save_helper(GenesisMakerBlock),
+                _BlockHash = add_internal(GenesisMakerBlock),
+                I = keys:pubkey(),
+                M = constants:master_pub(),
+                if
+                    I == M -> keys:update_id(1);
+                    true -> ok
+                end,
+                block:hash(GenesisMakerBlock);
+            Top ->
+                Top
+        end,
+    spawn(fun() ->
+                  block_hashes:add(block:hash(GenesisMakerBlock))
+          end),
+    {ok, TopHash}.
+
+handle_call({add, Block}, _From, OldBlockHash) ->
+    %% Check which block is higher and store it's hash as the top.
+    %% For tiebreakers, prefer the older block.
+
+    OldBlock = block:read(OldBlockHash),
     NH = block:height(Block),
     OH = block:height(OldBlock),
-    New = if
-	NH > OH -> 
-		  Trees = block:trees(Block),
-		  NH = block:height(Block),
-		  tx_pool:absorb(Trees, [], NH),
-		  add_internal(Block);
-	true -> X
-    end,
-    {reply, 0, New};
-handle_call(_, _From, X) -> {reply, X, X}.
+    NewBlockHash =
+        case NH > OH of
+            true ->
+                Trees = block:trees(Block),
+                NH = block:height(Block),
+                tx_pool:absorb(Trees, [], NH),
+                _NewBlockHash = add_internal(Block);
+            false ->
+                OldBlockHash
+        end,
+    {reply, 0, NewBlockHash};
+handle_call(_, _From, BlockHash) ->
+    {reply, BlockHash, BlockHash}.
 
-add(Block) -> gen_server:call(?MODULE, {add, Block}).
-doit() -> gen_server:call(?MODULE, top).
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok = lager:warning("Top died!").
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% Internals
+
 add_internal(Block) ->
-    Y = block:hash(Block),
-    db:save(?LOC, Y),
-    Y.
-
-test() ->
-    ok.
+    BlockHash = block:hash(Block),
+    ok = db:save(?LOC, BlockHash),
+    BlockHash.

--- a/apps/ae_core/src/consensus/chain/top.erl
+++ b/apps/ae_core/src/consensus/chain/top.erl
@@ -30,7 +30,7 @@ start_link() ->
 %% gen_server callbacks
 
 init(ok) ->
-    lager:info("Start top"),
+    lager:info("Start ~p", [?MODULE]),
     GenesisMakerBlock = block:genesis_maker(),
     Top = db:read(?LOC),
     TopHash =
@@ -81,7 +81,7 @@ handle_info(_Info, State) ->
     {noreply, State}.
 
 terminate(_Reason, _State) ->
-    ok = lager:warning("Top died!").
+    ok = lager:warning("~p died!", [?MODULE]).
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.

--- a/apps/ae_core/src/consensus/tx_pool.erl
+++ b/apps/ae_core/src/consensus/tx_pool.erl
@@ -60,12 +60,12 @@ handle_call({absorb_tx, NewTrees, Tx}, _From, F) ->
     MaxBlockSize = governance:get_value(max_block_size, Governance),
     FinalTxs =
         case BlockSize > MaxBlockSize of
-               true ->
-                   lager:warning("Cannot absorb tx - block is already full"),
-                   F#f.txs;
-               false ->
-                   NewTxs
-           end,
+            true ->
+                lager:warning("Cannot absorb tx - block is already full"),
+                F#f.txs;
+            false ->
+                NewTxs
+        end,
     {reply, 0, F#f{txs = FinalTxs, trees = NewTrees}};
 handle_call({absorb, NewTrees, Txs, Height}, _From, _) ->
     {reply, 0, #f{txs = Txs, trees = NewTrees, height = Height}};
@@ -75,11 +75,11 @@ handle_call(data, _From, F) ->
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
-handle_info(_, State) ->
+handle_info(_Info, State) ->
     {noreply, State}.
 
 terminate(_Reason, _State) ->
-    ok = lager:error("Tx pool died!").
+    ok = lager:warning("Tx pool died!").
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.

--- a/apps/ae_core/src/consensus/tx_pool.erl
+++ b/apps/ae_core/src/consensus/tx_pool.erl
@@ -46,7 +46,7 @@ start_link() ->
 %% gen_server callbacks
 
 init(ok) ->
-    lager:info("Tx pool started"),
+    lager:info("~p started", [?MODULE]),
     State = current_state(),
     {ok, State}.
 
@@ -79,7 +79,7 @@ handle_info(_Info, State) ->
     {noreply, State}.
 
 terminate(_Reason, _State) ->
-    ok = lager:warning("Tx pool died!").
+    ok = lager:warning("~p died!", [?MODULE]).
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.

--- a/apps/ae_core/src/consensus/tx_pool.erl
+++ b/apps/ae_core/src/consensus/tx_pool.erl
@@ -1,50 +1,93 @@
 -module(tx_pool).
 -behaviour(gen_server).
-%this module holds the txs ready for the next block.
-%It needs to use txs:digest to keep track of the Accounts and Channels dicts. This module needs to be ready to share either of those dicts.
--export([start_link/0,code_change/3,handle_call/3,handle_cast/2,handle_info/2,init/1,terminate/2, 
-absorb/3,absorb_tx/2,dump/0,data/0,test/0]).
--record(f, {txs = [], trees, height = 0}).%block:genesis only stores a single account, so the first time account was updated should be a 1.
-init(ok) -> 
-    io:fwrite("tx pool started\n"),
-    %process_flag(trap_exit, true),
-    F = state_now(),
-    {ok, F}.
-state_now() ->
-    B = block:read(top:doit()),
-    #f{trees = block:trees(B), height = block:height(B)}.
-    
-start_link() -> gen_server:start_link({local, ?MODULE}, ?MODULE, ok, []).
-code_change(_OldVsn, State, _Extra) -> {ok, State}.
-terminate(_, _) -> io:format("tx pool died!"), ok.
-handle_info(_, X) -> {noreply, X}.
-handle_cast(_, X) -> {noreply, X}.
-handle_call(dump, _From, _) -> {reply, 0, state_now()};
-handle_call({absorb_tx, NewTrees, Tx}, _From, F) ->
-    NewTxs = [Tx|F#f.txs],
-    B = size(term_to_binary(NewTxs)),
-    Governance = trees:governance(NewTrees),
-    MBS = governance:get_value(max_block_size, Governance),
-    %MBS = constants:max_block_size(),
-    FinalTxs = if
-	B > MBS -> 
-		       io:fwrite("block is already full\n"),
-		       F#f.txs;
-	true -> NewTxs
-    end,
-    {reply, 0, F#f{txs = FinalTxs, trees = NewTrees}}; 
-handle_call({absorb, NewTrees, Txs, Height}, _From, _) ->
-    {reply, 0, #f{txs = Txs, trees = NewTrees, height = Height}};
-handle_call(data, _From, F) -> {reply, {F#f.trees, F#f.height, flip(F#f.txs)}, F}.
-data() -> gen_server:call(?MODULE, data). %{accounts, channels, height, txs}
-dump() -> gen_server:call(?MODULE, dump).
-absorb_tx(Trees, Tx) -> 
+
+%% This module holds the txs ready for the next block.
+%% It needs to use txs:digest to keep track of the Accounts and Channels dicts.
+%% This module needs to be ready to share either of those dicts.
+
+%% API
+-export([data/0,
+         dump/0,
+         absorb_tx/2,
+         absorb/3]).
+
+-export([start_link/0]).
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-record(f, {txs = [],
+            trees,
+            height = 0}).
+
+%% API functions
+
+data() ->
+    {Trees, Height, Txs} = gen_server:call(?MODULE, data),
+    {Trees, Height, Txs}.
+
+dump() ->
+    gen_server:call(?MODULE, dump).
+
+absorb_tx(Trees, Tx) ->
     gen_server:call(?MODULE, {absorb_tx, Trees, Tx}).
+
 absorb(Trees, Txs, Height) ->
     gen_server:call(?MODULE, {absorb, Trees, Txs, Height}).
-flip(X) -> flip(X, []).
-flip([], A) -> A;
-flip([H|T], A) -> flip(T, [H|A]).
-    
-test() ->
-    success.
+
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, ok, []).
+
+
+%% gen_server callbacks
+
+init(ok) ->
+    lager:info("Tx pool started"),
+    State = current_state(),
+    {ok, State}.
+
+handle_call(dump, _From, _OldState) ->
+    State = current_state(),
+    {reply, 0, State};
+handle_call({absorb_tx, NewTrees, Tx}, _From, F) ->
+    NewTxs = [Tx | F#f.txs],
+    BlockSize = size(term_to_binary(NewTxs)),
+    Governance = trees:governance(NewTrees),
+    MaxBlockSize = governance:get_value(max_block_size, Governance),
+    FinalTxs =
+        case BlockSize > MaxBlockSize of
+               true ->
+                   lager:warning("Cannot absorb tx - block is already full"),
+                   F#f.txs;
+               false ->
+                   NewTxs
+           end,
+    {reply, 0, F#f{txs = FinalTxs, trees = NewTrees}};
+handle_call({absorb, NewTrees, Txs, Height}, _From, _) ->
+    {reply, 0, #f{txs = Txs, trees = NewTrees, height = Height}};
+handle_call(data, _From, F) ->
+    {reply, {F#f.trees, F#f.height, lists:reverse(F#f.txs)}, F}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok = lager:error("Tx pool died!").
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+
+%% Internals
+
+current_state() ->
+    Block = block:read(top:doit()),
+    #f{trees = block:trees(Block),
+       height = block:height(Block)}.

--- a/apps/ae_core/src/consensus/tx_pool_feeder.erl
+++ b/apps/ae_core/src/consensus/tx_pool_feeder.erl
@@ -1,61 +1,94 @@
 -module(tx_pool_feeder).
 -behaviour(gen_server).
--export([start_link/0,code_change/3,handle_call/3,handle_cast/2,handle_info/2,init/1,terminate/2, absorb/1, absorb_unsafe/1]).
-init(ok) -> {ok, []}.
-start_link() -> gen_server:start_link({local, ?MODULE}, ?MODULE, ok, []).
-code_change(_OldVsn, State, _Extra) -> {ok, State}.
-terminate(_, _) -> io:format("died!"), ok.
-handle_info(_, X) -> {noreply, X}.
-handle_cast({absorb, SignedTx}, X) ->
+
+%% API
+-export([absorb/1,
+         absorb_unsafe/1]).
+
+-export([start_link/0]).
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+%% API functions
+
+absorb(Txs) when is_list(Txs) ->
+    [absorb(Tx) || Tx <- Txs];
+
+absorb(SignedTx) ->
+    {_, _, Txs} = tx_pool:data(),
+    case is_in(SignedTx, Txs) of
+        true ->
+            ok;
+        false ->
+            gen_server:cast(?MODULE, {absorb, SignedTx})
+    end.
+
+absorb_unsafe(SignedTx) ->
+    {Trees, Height, _} = tx_pool:data(),
+    absorb_unsafe(SignedTx, Trees, Height).
+
+absorb_unsafe(SignedTx, Trees, Height) ->
+    NewTrees = txs:digest([SignedTx], Trees, Height + 1),
+    tx_pool:absorb_tx(NewTrees, SignedTx).
+
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, ok, []).
+
+
+%% gen_server callbacks
+
+init(ok) ->
+    {ok, []}.
+
+handle_call(_, _From, State) ->
+    {reply, State, State}.
+
+handle_cast({absorb, SignedTx}, State) ->
     {Trees, Height, Txs} = tx_pool:data(),
     Governance = trees:governance(Trees),
     Tx = testnet_sign:data(SignedTx),
     Fee = element(4, Tx),
-    %io:fwrite("tx pool feeder tx "),
-    %io:fwrite(packer:pack(Tx)),
-    %io:fwrite("\n"),
     Type = element(1, Tx),
     Cost = governance:get_value(Type, Governance),
     {ok, MinimumTxFee} = application:get_env(ae_core, minimum_tx_fee),
     true = Fee > (MinimumTxFee + Cost),
     Accounts = trees:accounts(Trees),
     true = testnet_sign:verify(SignedTx, Accounts),
-    B = is_in(SignedTx, Txs), %this is very ugly. once we have a proper CLI we can get rid of this crutch.
-    if
-	B ->  io:fwrite("already have this tx"),
-	    ok;
-	true ->
-	    absorb_unsafe(SignedTx, Trees, Height)
-    end,
-    {noreply, X};
-handle_cast(_, X) -> {noreply, X}.
-handle_call(_, _From, X) -> {reply, X, X}.
-absorb_unsafe(SignedTx) -> 
-    {Trees, Height, _} = tx_pool:data(),
-    absorb_unsafe(SignedTx, Trees, Height).
-absorb_unsafe(SignedTx, Trees, Height) -> 
-    NewTrees = 
-	txs:digest([SignedTx], Trees, Height+1),
-    tx_pool:absorb_tx(NewTrees, SignedTx).
-    
-absorb(Txs) when is_list(Txs) ->
-    [absorb(Tx) || Tx <- Txs];
-
-absorb(SignedTx) -> 
-    {_, _, Txs} = tx_pool:data(),
-    B = is_in(SignedTx, Txs),
-    if
-        B -> ok;
+    case is_in(SignedTx, Txs) of
         true ->
-            gen_server:cast(?MODULE, {absorb, SignedTx})
-    end.
+            ok = lager:info("Already have this tx");
+        false ->
+            absorb_unsafe(SignedTx, Trees, Height)
+    end,
+    {noreply, State};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
 
-is_in(_, []) -> false;
-is_in(STx, [STx2|T]) ->
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok = lager:warning("Tx pool feeder died!").
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+
+%% Internals
+
+is_in(_, []) ->
+    false;
+is_in(STx, [STx2 | T]) ->
     Tx = testnet_sign:data(STx),
     Tx2 = testnet_sign:data(STx2),
-    if
-	Tx == Tx2 -> true;
-	true -> is_in(STx, T)
+    case Tx == Tx2 of
+        true ->
+            true;
+        false ->
+            is_in(STx, T)
     end.
-

--- a/apps/ae_core/src/consensus/tx_pool_feeder.erl
+++ b/apps/ae_core/src/consensus/tx_pool_feeder.erl
@@ -73,7 +73,7 @@ handle_info(_Info, State) ->
     {noreply, State}.
 
 terminate(_Reason, _State) ->
-    ok = lager:warning("Tx pool feeder died!").
+    ok = lager:warning("~p died!", [?MODULE]).
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.

--- a/apps/ae_core/src/consensus/txs/testnet_sign.erl
+++ b/apps/ae_core/src/consensus/txs/testnet_sign.erl
@@ -1,8 +1,6 @@
 -module(testnet_sign).
 -export([test/0,test2/1,test3/0,sign_tx/5,sign/2,verify_sig/3,shared_secret/2,verify/2,data/1,
-	 %revealed/1,
 	 empty/1,empty/0,
-	 %set_revealed/2,
 	 verify_1/2,verify_2/2, pubkey2address/1, valid_address/1, hard_new_key/0,new_key/0,pub/1,pub2/1,address2binary/1,binary2address/1]).
 -record(signed, {data="", sig="", pub = "", sig2="", pub2=""}).
 -define(cs, 8). %checksum size
@@ -11,15 +9,10 @@ pub2(X) -> X#signed.pub2.
 empty() -> #signed{}.
 empty(X) -> #signed{data=X}.
 data(X) -> X#signed.data.
-%set_revealed(X, R) -> 
-%    X#signed{revealed = R}.
-%revealed(X) -> X#signed.revealed.
 en(X) -> base64:encode(X).
 de(X) -> base64:decode(X).
 params() -> crypto:ec_curve(secp256k1).
 shared_secret(Pub, Priv) -> en(crypto:compute_key(ecdh, de(Pub), de(Priv), params())).
-%to_bytes(X) -> term_to_binary(X).
-to_bytes(X) -> term_to_binary(X).
 generate() -> crypto:generate_key(ecdh, params()).
 new_key() -> %We keep this around for the encryption library. it is used to generate 1-time encryption keys.
     {Pub, Priv} = generate(),%crypto:generate_key(ecdh, params()),
@@ -136,16 +129,7 @@ checksum(N, <<>>) ->
 pubkey2address(P) when size(P) > 66 ->
     pubkey2address(base64:decode(P));
 pubkey2address(P) ->
-    %AB = (?AddressEntropy + 4),
-    %BC = (hash:hash_depth()*8) - AB,
-    %<< A:AB, T:BC >> = hash:doit(P),
-    %S = T rem 5000,
-    %case S of
-	%0 ->
-	    binary2address(testnet_hasher:doit(P)).%;
-	%_ ->
-	%    {error, invalid_pubkey}
-    %end.
+    binary2address(testnet_hasher:doit(P)).
 address2binary(A) ->
     S = ?AddressEntropy,
     <<C:?cs, B:S>> = base58:base58_to_binary(binary_to_list((A))),

--- a/apps/ae_core/src/consensus/txs/txs.erl
+++ b/apps/ae_core/src/consensus/txs/txs.erl
@@ -1,47 +1,87 @@
 -module(txs).
 -behaviour(gen_server).
--export([start_link/0,code_change/3,handle_call/3,handle_cast/2,handle_info/2,init/1,terminate/2, dump/0,txs/0,digest/3,fees/1]).
-init(ok) -> {ok, []}.
-start_link() -> gen_server:start_link({local, ?MODULE}, ?MODULE, ok, []).
-code_change(_OldVsn, State, _Extra) -> {ok, State}.
-terminate(_, _) -> io:format("txs died!"), ok.
-handle_info(_, X) -> {noreply, X}.
-handle_call(txs, _From, X) -> {reply, X, X}.
-handle_cast(dump, _) -> {noreply, []};
-handle_cast({add_tx, Tx}, X) -> {noreply, [Tx|X]}.
-dump() -> gen_server:cast(?MODULE, dump).
-txs() -> gen_server:call(?MODULE, txs).
-digest([], Trees, _) -> Trees;
-digest([SignedTx|Txs], Trees, Height) ->
+
+%% API
+-export([dump/0,
+	     txs/0,
+	     digest/3,
+	     fees/1]).
+
+-export([start_link/0]).
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+
+%% API functions
+
+dump() ->
+	gen_server:cast(?MODULE, dump).
+
+txs() ->
+	gen_server:call(?MODULE, txs).
+
+digest([], Trees, _) ->
+	Trees;
+digest([SignedTx | Txs], Trees, Height) ->
     Accounts = trees:accounts(Trees),
     true = testnet_sign:verify(SignedTx, Accounts),
     Tx = testnet_sign:data(SignedTx),
-    %io:fwrite("txs digest "),
-    %io:fwrite(packer:pack(Tx)),
-    %io:fwrite("\n"),
     NewTrees = digest2(Tx, Trees, Height),
     digest(Txs, NewTrees, Height).
 digest2(Tx, Trees, H) ->
     case element(1, Tx) of
-	ca -> create_account_tx:doit(Tx, Trees, H);
-	spend -> spend_tx:doit(Tx, Trees, H);
-	da -> delete_account_tx:doit(Tx, Trees, H);
-	repo -> repo_tx:doit(Tx, Trees, H);
-	nc -> new_channel_tx:doit(Tx, Trees, H);
-	gc -> grow_channel_tx:doit(Tx, Trees, H);
-	ctc -> channel_team_close_tx:doit(Tx, Trees, H);
-	cr -> channel_repo_tx:doit(Tx, Trees, H);
-	csc -> channel_solo_close:doit(Tx, Trees, H);
-	timeout -> channel_timeout_tx:doit(Tx, Trees, H);
-	cs -> channel_slash_tx:doit(Tx, Trees, H);
-	ex -> existence_tx:doit(Tx, Trees, H);
-	oracle_new -> oracle_new_tx:doit(Tx, Trees, H);
-	oracle_bet -> oracle_bet_tx:doit(Tx, Trees, H);
-	oracle_close -> oracle_close_tx:doit(Tx, Trees, H);
-	unmatched -> oracle_unmatched_tx:doit(Tx, Trees,H);
-	oracle_shares -> oracle_shares_tx:doit(Tx,Trees,H);
-	X -> X=2
+        ca -> create_account_tx:doit(Tx, Trees, H);
+        spend -> spend_tx:doit(Tx, Trees, H);
+        da -> delete_account_tx:doit(Tx, Trees, H);
+        repo -> repo_tx:doit(Tx, Trees, H);
+        nc -> new_channel_tx:doit(Tx, Trees, H);
+        gc -> grow_channel_tx:doit(Tx, Trees, H);
+        ctc -> channel_team_close_tx:doit(Tx, Trees, H);
+        cr -> channel_repo_tx:doit(Tx, Trees, H);
+        csc -> channel_solo_close:doit(Tx, Trees, H);
+        timeout -> channel_timeout_tx:doit(Tx, Trees, H);
+        cs -> channel_slash_tx:doit(Tx, Trees, H);
+        ex -> existence_tx:doit(Tx, Trees, H);
+        oracle_new -> oracle_new_tx:doit(Tx, Trees, H);
+        oracle_bet -> oracle_bet_tx:doit(Tx, Trees, H);
+        oracle_close -> oracle_close_tx:doit(Tx, Trees, H);
+        unmatched -> oracle_unmatched_tx:doit(Tx, Trees,H);
+        oracle_shares -> oracle_shares_tx:doit(Tx,Trees,H);
+        X -> X = 2
     end.
-fees([]) -> 0;
-fees([H|T]) -> 
+
+fees([]) ->
+	0;
+fees([H | T]) ->
     element(4, element(2, H)) + fees(T).
+
+
+start_link() ->
+	gen_server:start_link({local, ?MODULE}, ?MODULE, ok, []).
+
+
+%% gen_server callbacks
+
+init(ok) ->
+	{ok, []}.
+
+handle_call(txs, _From, Txs) ->
+	{reply, Txs, Txs}.
+
+handle_cast(dump, _) ->
+	{noreply, []};
+handle_cast({add_tx, Tx}, Txs) ->
+	{noreply, [Tx | Txs]}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok = lager:warning("Txs died!").
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/apps/ae_core/src/consensus/txs/txs.erl
+++ b/apps/ae_core/src/consensus/txs/txs.erl
@@ -15,7 +15,6 @@
          terminate/2,
          code_change/3]).
 
-
 %% API functions
 
 dump() ->
@@ -81,7 +80,7 @@ handle_info(_Info, State) ->
     {noreply, State}.
 
 terminate(_Reason, _State) ->
-    ok = lager:warning("Txs died!").
+    ok = lager:warning("~p died!", [?MODULE]).
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.


### PR DESCRIPTION
Simplify `tx_pool`, `txs`, `top` and `tx_pool_feeder`:
* `lists:reverse` instead of `flip`
* better naming & formatting