### PR TITLE
README: Fix links to getting started guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Written in Erlang.
 
 You will need Erlang and a couple of libraries before you are able to run this software.
 
-[For Ubuntu](docs/ubuntu_dependencies.md)
+[For Ubuntu](docs/getting-started/ubuntu_dependencies.md)
 
-[For Mac](docs/mac_dependencies.md)
+[For Mac](docs/getting-started/mac_dependencies.md)
 
 
 #### Running the blockchain


### PR DESCRIPTION
Fix dead links in `README.md`:
* `For Ubuntu`
* `For Mac`