### PR TITLE
channel_balance: use the other party's public key as argument

### DIFF
--- a/apps/ae_api/src/api.erl
+++ b/apps/ae_api/src/api.erl
@@ -9,7 +9,8 @@
 -export([create_account/2, delete_account/1, account/1,
          repo_account/1, repo_account/2, coinbase/1]).
 
--export([channel_balance/0,
+-export([%%channel_balance/0, 
+         channel_balance/1,
          new_channel_with_server/3, pull_channel_state/2,
          add_secret/2, pull_channel_state/0, channel_spend/1, channel_spend/3,
          new_channel_tx/6, new_channel_tx/7, close_channel_with_server/0,
@@ -255,24 +256,24 @@ channel_manager_update(ServerID, SSPK2, DefaultSS) ->
     channel_manager:write(ServerID, NewCD),
     ok.
 
-channel_balance() ->
-    %% Why prod address?
-    channel_balance(constants:server_ip(), constants:server_port()).
+%% channel_balance() ->
+%%     %% Why prod address?
+%%     channel_balance(constants:server_ip(), constants:server_port()).
 
-channel_balance(Ip, Port) ->
-    Balance = integer_channel_balance(Ip, Port),
-    FormattedBalance = pretty_display(Balance),
-    lager:info("Channel balance: ~p", [FormattedBalance]),
-    FormattedBalance.
+%% channel_balance(Ip, Port) ->
+%%     {ok, OtherPubKey} = talker:talk({pubkey}, Ip, Port),
+%%     Balance = channel_balance(OtherPubKey).
+%%     FormattedBalance = pretty_display(Balance),
+%%     lager:info("Channel balance: ~p", [FormattedBalance]),
+%%     FormattedBalance.
 
-integer_channel_balance(Ip, Port) ->
-    {ok, Other} = talker:talk({pubkey}, Ip, Port),
-    {ok, CD} = channel_manager:read(Other),
+channel_balance(OtherPubKey) ->
+    {ok, CD} = channel_manager:read(OtherPubKey),
     SSPK = channel_feeder:them(CD),
     SPK = testnet_sign:data(SSPK),
     SS = channel_feeder:script_sig_them(CD),
     {Trees, NewHeight, _Txs} = tx_pool:data(),
-    Channels = trees:accounts(Trees),
+    Channels = trees:channels(Trees),
     {Amount, _, _, _} = spk:run(fast, SS, SPK, NewHeight, 0, Trees),
     CID = spk:cid(SPK),
     {_, Channel, _} = channels:get(CID, Channels),

--- a/apps/ae_api/src/api.erl
+++ b/apps/ae_api/src/api.erl
@@ -9,8 +9,7 @@
 -export([create_account/2, delete_account/1, account/1,
          repo_account/1, repo_account/2, coinbase/1]).
 
--export([%%channel_balance/0, 
-         channel_balance/1,
+-export([channel_balance/1,
          new_channel_with_server/3, pull_channel_state/2,
          add_secret/2, pull_channel_state/0, channel_spend/1, channel_spend/3,
          new_channel_tx/6, new_channel_tx/7, close_channel_with_server/0,
@@ -255,17 +254,6 @@ channel_manager_update(ServerID, SSPK2, DefaultSS) ->
     NewCD = channel_feeder:new_cd(SPK, SSPK2, [DefaultSS|MeSS], [DefaultSS|ThemSS], Entropy, CID),
     channel_manager:write(ServerID, NewCD),
     ok.
-
-%% channel_balance() ->
-%%     %% Why prod address?
-%%     channel_balance(constants:server_ip(), constants:server_port()).
-
-%% channel_balance(Ip, Port) ->
-%%     {ok, OtherPubKey} = talker:talk({pubkey}, Ip, Port),
-%%     Balance = channel_balance(OtherPubKey).
-%%     FormattedBalance = pretty_display(Balance),
-%%     lager:info("Channel balance: ~p", [FormattedBalance]),
-%%     FormattedBalance.
 
 channel_balance(OtherPubKey) ->
     {ok, CD} = channel_manager:read(OtherPubKey),

--- a/apps/ae_http/priv/swagger.json
+++ b/apps/ae_http/priv/swagger.json
@@ -510,17 +510,29 @@
       }
     },
     "/channel-balance" : {
-      "get" : {
+      "post" : {
         "tags" : [ "internal" ],
         "operationId" : "ChannelBalance",
+        "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
-        "parameters" : [ ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "body",
+          "description" : "IP and port specifying channel",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/ChannelBalance"
+          }
+        } ],
         "responses" : {
           "200" : {
             "description" : "successful operation",
             "schema" : {
-              "$ref" : "#/definitions/ChannelBalance"
+              "$ref" : "#/definitions/ChannelBalanceValue"
             }
+          },
+          "405" : {
+            "description" : "Invalid input"
           }
         },
         "security" : [ ]
@@ -845,8 +857,17 @@
     "ChannelBalance" : {
       "type" : "object",
       "properties" : {
-        "balance" : {
+        "pubkey" : {
           "type" : "string"
+        }
+      }
+    },
+    "ChannelBalanceValue" : {
+      "type" : "object",
+      "properties" : {
+        "balance" : {
+          "type" : "integer",
+          "format" : "int64"
         }
       }
     },

--- a/apps/ae_http/priv/swagger.json
+++ b/apps/ae_http/priv/swagger.json
@@ -528,7 +528,7 @@
           "200" : {
             "description" : "successful operation",
             "schema" : {
-              "$ref" : "#/definitions/ChannelBalanceValue"
+              "$ref" : "#/definitions/ChannelBalanceResult"
             }
           },
           "405" : {
@@ -862,14 +862,9 @@
         }
       }
     },
-    "ChannelBalanceValue" : {
-      "type" : "object",
-      "properties" : {
-        "balance" : {
-          "type" : "integer",
-          "format" : "int64"
-        }
-      }
+    "ChannelBalanceResult" : {
+      "type" : "integer",
+      "format" : "int64"
     },
     "Secret" : {
       "type" : "object",

--- a/apps/ae_http/src/ae_http_dispatch_int.erl
+++ b/apps/ae_http/src/ae_http_dispatch_int.erl
@@ -185,9 +185,11 @@ handle_request('MineBlock', Req, _Context) ->
     ok = api:mine_block(Count, Times),
     {200, [], #{}};
 
-handle_request('ChannelBalance', _Req, _Context) ->
-    ChannelBalance = api:channel_balance(),
-    {200, [], #{<<"balance">> => list_to_binary(ChannelBalance)}};
+handle_request('ChannelBalance', Req, _Context) ->
+    CB = maps:get('ChannelBalance', Req),
+    PK = base64:decode(maps:get(<<"pubkey">>, CB)),
+    Val = api:channel_balance(PK),
+    {200, [], #{<<"balance">> => Val}};
 
 handle_request('ChannelSoloClose', _Req, _Context) ->
     ok = api:channel_solo_close(),

--- a/apps/ae_http/src/ae_http_dispatch_int.erl
+++ b/apps/ae_http/src/ae_http_dispatch_int.erl
@@ -189,7 +189,7 @@ handle_request('ChannelBalance', Req, _Context) ->
     CB = maps:get('ChannelBalance', Req),
     PK = base64:decode(maps:get(<<"pubkey">>, CB)),
     Val = api:channel_balance(PK),
-    {200, [], #{<<"balance">> => Val}};
+    {200, [], Val};
 
 handle_request('ChannelSoloClose', _Req, _Context) ->
     ok = api:channel_solo_close(),

--- a/apps/ae_http/src/swagger/swagger_api.erl
+++ b/apps/ae_http/src/swagger/swagger_api.erl
@@ -388,7 +388,7 @@ validate_response('AddSecret', 405, Body, ValidatorState) ->
     validate_response_body('', '', Body, ValidatorState);
 
 validate_response('ChannelBalance', 200, Body, ValidatorState) ->
-    validate_response_body('ChannelBalanceValue', 'ChannelBalanceValue', Body, ValidatorState);
+    validate_response_body('ChannelBalanceResult', 'ChannelBalanceResult', Body, ValidatorState);
 validate_response('ChannelBalance', 405, Body, ValidatorState) ->
     validate_response_body('', '', Body, ValidatorState);
 

--- a/apps/ae_http/src/swagger/swagger_api.erl
+++ b/apps/ae_http/src/swagger/swagger_api.erl
@@ -46,6 +46,7 @@ request_params('AddSecret') ->
 
 request_params('ChannelBalance') ->
     [
+        'ChannelBalance'
     ];
 
 request_params('ChannelSoloClose') ->
@@ -204,6 +205,15 @@ request_param_info('AddPeer', 'Peer') ->
     };
 
 request_param_info('AddSecret', 'Secret') ->
+    #{
+        source =>   body,
+        rules => [
+            schema,
+            required
+        ]
+    };
+
+request_param_info('ChannelBalance', 'ChannelBalance') ->
     #{
         source =>   body,
         rules => [
@@ -378,7 +388,9 @@ validate_response('AddSecret', 405, Body, ValidatorState) ->
     validate_response_body('', '', Body, ValidatorState);
 
 validate_response('ChannelBalance', 200, Body, ValidatorState) ->
-    validate_response_body('ChannelBalance', 'ChannelBalance', Body, ValidatorState);
+    validate_response_body('ChannelBalanceValue', 'ChannelBalanceValue', Body, ValidatorState);
+validate_response('ChannelBalance', 405, Body, ValidatorState) ->
+    validate_response_body('', '', Body, ValidatorState);
 
 validate_response('ChannelSoloClose', 405, Body, ValidatorState) ->
     validate_response_body('', '', Body, ValidatorState);

--- a/apps/ae_http/src/swagger/swagger_internal_handler.erl
+++ b/apps/ae_http/src/swagger/swagger_internal_handler.erl
@@ -83,7 +83,7 @@ allowed_methods(
         operation_id = 'ChannelBalance'
     }
 ) ->
-    {[<<"GET">>], Req, State};
+    {[<<"POST">>], Req, State};
 
 allowed_methods(
     Req,

--- a/apps/ae_http/src/swagger/swagger_router.erl
+++ b/apps/ae_http/src/swagger/swagger_router.erl
@@ -87,7 +87,7 @@ get_operations() ->
         },
         'ChannelBalance' => #{
             path => "/v1/channel-balance",
-            method => <<"GET">>,
+            method => <<"POST">>,
             handler => 'swagger_internal_handler'
         },
         'ChannelSoloClose' => #{

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -457,7 +457,7 @@ paths:
         '200':
           description: successful operation
           schema:
-            $ref: '#/definitions/ChannelBalanceValue'
+            $ref: '#/definitions/ChannelBalanceResult'
         '405':
           description: Invalid input
       security: []
@@ -693,12 +693,9 @@ definitions:
     properties:
       pubkey:
         type: string
-  ChannelBalanceValue:
-    type: object
-    properties:
-      balance:
-        type: integer
-        format: int64
+  ChannelBalanceResult:
+    type: integer
+    format: int64
   Secret:
     type: object
     properties:

--- a/config/swagger.yaml
+++ b/config/swagger.yaml
@@ -438,18 +438,28 @@ paths:
           description: Invalid input
       security: []
   /channel-balance:
-    get:
+    post:
       tags:
         - internal
       operationId: ChannelBalance
+      consumes:
+        - application/json
       produces:
         - application/json
-      parameters: []
+      parameters:
+        - in: body
+          name: body
+          description: 'IP and port specifying channel'
+          required: true
+          schema:
+            $ref: '#/definitions/ChannelBalance'
       responses:
         '200':
           description: successful operation
           schema:
-            $ref: '#/definitions/ChannelBalance'
+            $ref: '#/definitions/ChannelBalanceValue'
+        '405':
+          description: Invalid input
       security: []
   /channel-solo-close:
     post:
@@ -681,8 +691,14 @@ definitions:
   ChannelBalance:
     type: object
     properties:
-      balance:
+      pubkey:
         type: string
+  ChannelBalanceValue:
+    type: object
+    properties:
+      balance:
+        type: integer
+        format: int64
   Secret:
     type: object
     properties:

--- a/tests/swagger.py
+++ b/tests/swagger.py
@@ -201,9 +201,10 @@ class IntAPI(API):
         r = self.session.post(uri, json=data)
         return r.status_code
 
-    def channel_balance(self):
+    def channel_balance(self, pubkey):
         uri = self.URL + '/channel-balance'
-        r = self.session.get(uri)
+        data = {'pubkey': pubkey}
+        r = self.session.post(uri, json=data)
         code = r.status_code
         if code != 200:
             return code, None

--- a/tests/swagger.py
+++ b/tests/swagger.py
@@ -208,7 +208,7 @@ class IntAPI(API):
         code = r.status_code
         if code != 200:
             return code, None
-        return code, r.json()['balance']
+        return code, r.json()
 
     def channel_solo_close(self):
         uri = self.URL + '/channel-solo-close'

--- a/tests/test_swagger_int.py
+++ b/tests/test_swagger_int.py
@@ -76,12 +76,24 @@ class InternalAPITest(SwaggerTest):
         self.c(api.fetch_account(pub2))
         # XXX check pub2's balance?
 
-    # todo: fix api:integer_channel_balance/0
-    @nottest
     def test_channel_balance(self):
-        api = self.API['dev1']
-        balance = self.c(api.channel_balance(pub2))
-        self.assertIsNotNone(balance)
+        api1 = self.API['dev1']
+        api2 = self.API['dev2']
+
+        # grab dev1's pubkey
+        pub1 = self.c(api1.fetch_pubkey())
+        # sync dev1 with dev2
+        self.c(api1.sync('127.0.0.1', 3020)); sleep(0.5)
+        # set keys on dev2
+        pub2, priv2 = self.c(api2.create_keypair())
+        self.c(api2.set_keypair(pub2, priv2))
+        # let dev1 know about dev2
+        self.c(api1.create_account_with_key(pub2, 10)); sleep(0.5)
+        # create channel
+        self.c(api1.new_channel_with_server('127.0.0.1', 3020, 1, 10000, 10001, 50, 4)); sleep(0.1)
+        # ask channel balance
+        balance = self.c(api1.channel_balance(pub2))
+        self.assertEqual(10000, balance)
 
     @nottest
     def test_channel_solo_close(self):

--- a/tests/test_swagger_int.py
+++ b/tests/test_swagger_int.py
@@ -80,7 +80,7 @@ class InternalAPITest(SwaggerTest):
     @nottest
     def test_channel_balance(self):
         api = self.API['dev1']
-        balance = self.c(api.channel_balance())
+        balance = self.c(api.channel_balance(pub2))
         self.assertIsNotNone(balance)
 
     @nottest


### PR DESCRIPTION
This function is useful for debugging payment tests.
(#291)