### PR TITLE
Added external API function block_sizecap

### DIFF
--- a/apps/ae_core/src/consensus/chain/block.erl
+++ b/apps/ae_core/src/consensus/chain/block.erl
@@ -2,7 +2,7 @@
 
 -export([block_to_header/1, test/0,
          height/1, prev_hash/1, txs/1, trees_hash/1, time/1, difficulty/1, comment/1, version/1, pow/1, trees/1, prev_hashes/1, 
-         get_by_height_in_chain/2, get_by_height/1, hash/1, get_by_hash/1, initialize_chain/0, make/4,
+         get_by_height_in_chain/2, get_by_height/1, get_with_sizecap/2, hash/1, get_by_hash/1, initialize_chain/0, make/4,
          mine/1, mine/2, mine2/2, check/1, 
          guess_number_of_cpu_cores/0, top/0,
          serialize/1, deserialize/1
@@ -154,6 +154,26 @@ get_by_height_in_chain(N, BH) when N > -1 ->
             end
     end.
 
+get_block(Block) when is_integer(Block) ->
+    get_by_height(Block);
+get_block(Block) -> %if it's not an integer then it's hash
+    get_by_hash(Block).
+
+get_with_sizecap(Cur, Cap) ->
+    X = get_block(Cur),
+    get_with_sizecap_internal(X, Cap).
+
+get_with_sizecap_internal(empty, _) ->
+    [];
+get_with_sizecap_internal(X, Cap) ->
+    Xsize = iolist_size(packer:pack(X)) + 1, %+1 for the delimeter char (,)
+    case Xsize > Cap of
+        true ->
+            [];
+        false ->
+            PH = prev_hash(X),
+            [X | get_with_sizecap(PH, Cap - Xsize)]
+end.
 
 prev_hash(0, BP) ->
     prev_hash(BP);

--- a/apps/ae_core/src/consensus/packer.erl
+++ b/apps/ae_core/src/consensus/packer.erl
@@ -48,6 +48,7 @@ is_b_atom(<<"pow">>) -> true;
 is_b_atom(<<"prev_hashes">>) -> true;
 is_b_atom(<<"error">>) -> true;
 is_b_atom(<<"block">>) -> true;
+is_b_atom(<<"block_sizecap">>) -> true;
 is_b_atom(<<"block_plus">>) -> true;
 is_b_atom(<<"ex">>) -> true;
 is_b_atom(<<"timeout">>) -> true;

--- a/apps/ae_http/src/ext_handler.erl
+++ b/apps/ae_http/src/ext_handler.erl
@@ -40,6 +40,8 @@ doit({give_block, SerializedSignedBlock}) ->
 doit({block, N}) when is_integer(N), N >= 0 ->
     lager:info("received request for block ~p", [N]),
     {ok, block:serialize(block:get_by_height(N))};
+doit({block_sizecap, N, Cap}) ->
+    {ok, block:get_with_sizecap(N, Cap - 10)};  %-10 for some begining and end addictional characters
 doit({header, N}) -> 
     {ok, block:block_to_header(block:get_by_height(N))};
 doit({headers, Many, N}) -> 

--- a/tests/test_sizecap.py
+++ b/tests/test_sizecap.py
@@ -1,0 +1,10 @@
+from base import ApiUser, DEV_1, OK_RESPONSE
+from nose.tools import nottest
+
+
+class SizecapTest(ApiUser):
+    def test_sizecap(self):
+        top_block_height = self.top(DEV_1, [])[2]
+        response = self.request('block_sizecap', DEV_1, [top_block_height, 10**6])
+        if len(response[1]) < 10:
+            self.assertEqual(len(response[1]), top_block_height+2)  #2 = 1 for genesis + 1 for magic element (-6)


### PR DESCRIPTION
The introduced function will be used by new synchronization code. It was part of #227 that will be closed, due to being to complex. The better `download_blocks` code that won't be merged from #227 was causing too much problems in review and will be replaced anyway. This is the only part of that code we will use.

The reason to merge this is to make sure new changes won't break this. I'm not sure if that's enough to merge such not used code.