### PR TITLE
Document functions for retrieving block

### DIFF
--- a/docs/api/commands_other.md
+++ b/docs/api/commands_other.md
@@ -3,16 +3,31 @@ Other commands
 
 
 ##### To see the transactions currently in the mempool, which will be included in the next block.
-```
+```erlang
 api:mempool().
 ```
 
-#### Lookup block number 5
-```
+#### Lookup block number 5 in current block chain
+```erlang
 block:get_by_height(5).
 ```
 
-### Lookup the top blocks
+#### Lookup block whose header has the specified hash
+```erlang
+block:get_by_hash(<<"The32BytesLongHashOfABlockHeader">>).
 ```
-block:get_by_height(api:height()).
+
+#### Lookup block number 5 in a specific block chain
+The specified hash of the block header identifies a block.  Lookup the
+block at height 5 in the chain that goes from such block to the
+genesis block.
+```erlang
+{ok, Header} = headers:read(<<"The32BytesLongHashOfABlockHeader">>),
+block:get_by_height(5, Header).
+```
+
+### Lookup the top block
+```erlang
+{ok, H} = api:height(),
+block:get_by_height(H).
 ```


### PR DESCRIPTION
Addresses https://github.com/aeternity/testnet/pull/275#issuecomment-320789291

@sennui 
* I avoided `@doc` as you recommended;
* I added "the diff between get-by-hash, get-by-height, get-by-height-in-chain" in docs/api/commands_other.md as I found it was already partially there, and I just had to integrate it;
* Function "get-by-height-in-chain" is used only in a test but I kept it as exported - it may be used when handling concurrent chains maybe;
* I understand that eventually the documentation shall not document the Erlang API but the HTTP one, but I integrated the existing one at the moment.