### PR TITLE
Improvements to documentation of evaluating bets

### DIFF
--- a/docs/design/lightning_payments.md
+++ b/docs/design/lightning_payments.md
@@ -32,7 +32,7 @@ We first grab the [scriptpubkey (SPK) and scriptsig (SS) scripts](smart_contract
         *   otherwise calculate hash of its top
             *   if matches the hash wired-in: [[], granularity, 2, 0]
             *   otherwise [[], 0, 1, 49]
-4.  generate **secret**: a compiled chalang declaration containing the random bytes generated, in base64 format.
+4.  generate **secret**: a compiled chalang code that just pushes a binary on the stack containing the random bytes generated, in base64 format.
 5.  (a sanity check is performed that creates and runs a new bet with arbitrary amount, accounts, CID and space/time gases)
 6.  return code, secret to `api:lightning_spend/7`
 
@@ -82,7 +82,7 @@ We tell the proxy node to make a locked payment, too, via `talker:talk`. On that
 
 #### sender updates channel data
 
-`api:lightning_spend/5` asks channel_manager to update data of the channel to proxy node with the received SPK on both sides and adding empty placeholders to SS's.
+`api:lightning_spend/5` asks channel_manager to update data of the channel to proxy node with the received SPK on both sides and adding empty placeholders to SS's (these, when evaluated in chalang, leave the stack empty).
 
 
 ### Activating payments on the path: pulling the channel
@@ -102,9 +102,8 @@ Revealing the secret and updating of channels takes place when the channel state
         *   the channel id is live in the view of both sides
         *   the signature on the SPK fetched is valid
         *   the the fetched SPK and channel data are consistent
-    2.  forced update of our SPK using our SS and their one from the fetched CD
-        `spk:force_update/3`
-        *   run with with both SSes
+    2.  forced update of our SPK using our SS and their one from the fetched CD: `spk:force_update/3`
+        *   run bets with with both SS'es:
             *   `spk:run/6`:
                 *   create Chalang state with block height we got from `tx_pool:data/0` and slash = 0 (i.e., not running as a solo_stop or slash transaction)
                 *   cycle through all SS elements and bets in our SPK: call a chain of `run` calls:
@@ -114,37 +113,36 @@ Revealing the secret and updating of channels takes place when the channel state
                     *   `spk:run3/7` with the first SS and bet
                         *   (crash if SS is ?crash)
                         *   `spk:prove_facts/2`: nothing to prove as field `prove` of our bet is empty
-                        *   `chalang:run5/2` both for SS and code
+                        *   `chalang:run5/2` first for SS and code.
                         *   return
                             *   Amount * Bet#bet.amount div granularity (in fact, amount is just 0 or 1 times granularity, indicating if payment happens),
-                            *   nonce (relative, starts from 0)
-                            *   shareRoot (always [] in our case) @@TODO: shares
+                            *   nonce: if SS declared the binary whose hash is the one the code expects nonce = 2 returned, 1 otherwise
+                            *   shareRoot (always [] in our case)
                             *   delay (indicates outcome of code execution, see lightning code above)
                             *   time_gas
-                        *   `spk:run/11` for the remainder
+                        *   `spk:run/11` for all the remainder of bets, SS'es
                 *   return SPK's original + collected amount, nonce, shares, maximum of delays
-        *   Check nonces:
-            *   unless new one is lower, to run all bets with the new SS'es and return
-                the new bets, SS'es amount and nonce
-            *   if higher: `channel_feeder:simplify_helper/2`: try to unlock bets in in the SPK of the CD in my side using their SS. `spk:bet_unlock/2`, calling `spk:bet_unlock/8`
-                *   if no secret can be read (`secret:read/1`) check next bet2
+        *   Check nonces calculated for both SS'es:
+            *   unless new one is lower, invoke `spk:force_update2/6` that runs all bets with the new SS'es and return the remaining bets, SS'es amount and nonce
+            *   if new nonce is higher: `channel_feeder:simplify_helper/2`: try to unlock bets in in the SPK of the CD in my side using their SS. `spk:bet_unlock/2`, calling `spk:bet_unlock/8`
+                *   if no secret can be read (`secret:read/1` with the `key` of the bet) check next bet
                 *   if secret available, try to run bet in chalang
-                *   if fails, try to run with 1st SS instead of secret
+                *   if fails, try to run with SS instead of secret
                     *   if that fails, too move on to next bet2
                     *   success: as next point
                 *   if succeeds, check delay in chalang stack
-                    *   > 50:  failure, move on (never happens in lightning, code returns max 50)
-                    *   success, add SS to secrets, accumulate amount, move on
+                    *   `>` 50:  failure, keep the bet and SS and move on trying the next one
+                    *   success, bet unlocked, accumulate amount, drop bet and SS from list and move on to next bet
                 *   return remaining SS, updated SPK, learned secrets, accumulated SS
             *   return remaining SS, new SPK (theirs) signed
     3.  Check if the update returns the SPK and SS of other side.
         *   If it does, accept it on our side: update our CD with these on our side.
             Sign and return the received SPK. This means tha if the other party found
             a way to unlock funds, we agree to give them.
-        *   If the update does not match it, accept if it is an improvement on our side.
-            (i.e., accept if they want to give us money.) (@@TODO: elaborate improvement)
-            Otherwise, try to unlock bets with the new SS received from the proxy node in
-            the CD (their side).
+        *   If the update does not match it, calculate if it is an improvement for us (`spk:is_improvement/4`). Accept it
+            *   if it is clear that we make profit on it
+            *   if we do not lose money on it and they make a bet that we can possibly win. In this case, check if the money we have on the channel above out obligations is enough to keep the channel open long enough for the bets.
+            If we decide to accept, sign and return the received SPK. Otherwise, try to unlock bets with the new SS received from the proxy node in the CD (their side; `channel_feeder:simplify_helper/2`) and return the resulting SPK.
 6.  Sync the result with the proxy node (call `channel_feeder:update_to_me/2` on other node)
 7.  Decrypt messages in CD, learn secrets in them
 8.  Unlock the secret:
@@ -159,21 +157,23 @@ Revealing the secret and updating of channels takes place when the channel state
         `api:teach_secrets/4`: call learn_secret on proxy node for each secret found via talker
         *   `ext_handler:doit({learn_secret, ...)`
             *   `secrets:add/2`
-            *   unlock bets (SS, SPK on the own side of the proxy node)
+            *   unlock bets (SS, SPK on the own side of the proxy node):
             *   if SS changed
                 *   update channel data
                 *   fetch pubkeys of other connected nodes referring to this code
                 *   update bets on these channels, too
-    *   update my side of channel data with the new SPK 
+    *   update my side of channel data with the new SPK
         `channel_feeder:update_to_me/2`
 
 ## Problems
 
-1.  chalang: duplication of opcodes, error-prone
+1.  Why do we use delay > 50 for testing if unlocking a bet succeeded? The code returns delay == 50 if SS was empty and 49 if contains a wrong secret.
 
-2.  almost all sanity tests rely on badmatch/crash
+2.  chalang: duplication of opcodes, error-prone
 
-3.  code duplication: running chalang for bets in several places
+3.  almost all sanity tests rely on badmatch/crash
+
+4.  code duplication: running chalang for bets in several places
 
 
 ## Glossary


### PR DESCRIPTION
@wagerlabs : I am not sure why we use the condition Delay > 50 for checking failure for unlocking a bet (in spk:bet_unlock3/11, spk:force_update2/6). The code in secrets:new_lightning/0 seems to return 50 if SS is empy and 49 in case of hash mismatch.