### PR TITLE
Documentation of block&header - in particular re Merkle tree

### DIFF
--- a/docs/design/blocks.md
+++ b/docs/design/blocks.md
@@ -16,6 +16,8 @@ leaf datum.
 
 ["State Merkle trees"](/docs/design/trees.md).
 
+["Transaction"](/docs/design/transaction_types.md).
+
 ## Block-related data structures exchanged on the network
 
 The following describes the block-related data structures as exchanged
@@ -27,10 +29,16 @@ representation of data structures in the Erlang codebase.
 
 The block includes:
 * [Block header](#block-header);
-* Transactions;
+* Ordered representation of transactions;
   ```erlang
   #block.txs
   ```
+  * The first transaction is a `coinbase` transaction;
+  * No transaction after the first can be a `coinbase` transaction;
+    * *TO-BE The codebase does not check that no `coinbase` transaction is present after the first.  This shall be checked.*
+  * Each transaction has objective constraints on its presence in the
+    block.  For details on such criteria, please refer to the Erlang
+    code implementing transactions (files `*_tx.erl`).
 * Partial representation of state Merkle trees (i.e. accounts,
   channels, proof of existence, proof of burn and oracles) before
   application of transactions, specifically proof and datum of each

--- a/docs/design/blocks.md
+++ b/docs/design/blocks.md
@@ -131,6 +131,12 @@ DB = 16,
 
 See also [aeternity whitepaper] subsection "II-E.2) Light clients".
 
+### Genesis block
+
+The genesis block is a special block whose accounts state Merkle tree
+consists of one account with key `0` and balance the initial amount of
+tokens.  See `block:genesis_maker/0`.
+
 ## Node-local model of blocks
 
 The following describes the node-local internal representation of

--- a/docs/design/blocks.md
+++ b/docs/design/blocks.md
@@ -56,6 +56,8 @@ The block includes:
       determined only from the information in the block.
   * *TO-BE The codebase holds a place but does not use such item.  The item shall be used.*
 
+The block is serialized as per function `block:serialize/1`.
+
 See also [aeternity whitepaper] subsection "II-A.4) Block contents".
 
 ### Block header


### PR DESCRIPTION
Closes #255.

I understand on Mon we may move documentation to other format, but I still find beneficial considering this PR for merge so that we can agree on it.